### PR TITLE
Included snippets, servers & certs for passenger

### DIFF
--- a/nginx/passenger.sls
+++ b/nginx/passenger.sls
@@ -11,6 +11,11 @@
 include:
   - nginx.pkg
   - nginx.service
+  {%- if nginx.snippets is defined %}
+  - nginx.snippets
+  {%- endif %}
+  - nginx.servers
+  - nginx.certificates
 
 passenger_install:
   pkg.installed:


### PR DESCRIPTION
- currently you're forced to define extra states if you opt to install nginx with passenger
- if you want the same outcome for passenger and nginx installs with equivalent config
- passenger is an extra module, makes no sense to end up with less config